### PR TITLE
CI workflow - free up disk space

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,12 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -
+        name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          docker system prune --all --force
+      -
         name: Build and push
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
CI workflow - free up disk space

## Summary by Sourcery

CI:
- Add a step to remove /usr/share/dotnet and /usr/local/lib/android and run docker system prune in the CI pipeline